### PR TITLE
[BON-1216]  Upgraded to use of `SafeLoader`.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -59,7 +59,10 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=R0201,W0613,I0021,I0020,C0111,W1618,W1619,R0902,R0903,W0231,W0611,R0913,W0703,C0330,R0204,I0011,R0904,R0205,R1705,R1710,W0403
+disable=
+    R0201,W0613,I0021,I0020,C0111,W1618,W1619,R0902,R0903,W0231,W0611,R0913,W0703,C0330,R0204,I0011,R0904,R0205,R1705,R1710,W0403,
+    bad-whitespace
+
 
 
 [REPORTS]
@@ -194,7 +197,7 @@ single-line-if-stmt=no
 no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
-max-module-lines=1000
+max-module-lines=1200
 
 # String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
 # tab).
@@ -357,13 +360,6 @@ ext-import-graph=
 # Create a graph of internal dependencies in the given file (report RP0402 must
 # not be disabled)
 int-import-graph=
-
-# Typing is a third party package in python 2, but built-in to the standard
-# library for Python 3. This causes linting issues when typing get grouped
-# with the third party package imports. Since chalice was originally written
-# just for Python 2, the code standard is to treat as a third party library
-# and thus mark it as so when linting.
-known-third-party=typing
 
 [EXCEPTIONS]
 

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,16 @@ check:
 	#
 	pydocstyle --add-ignore=D100,D101,D102,D103,D104,D105,D204,D301 chalice/
 
-pylint:
+lint:
 	###### PYLINT ######
 	pylint --rcfile .pylintrc chalice
 	# Run our custom linter on test code.
 	pylint --load-plugins tests.linter --disable=I,E,W,R,C,F --enable C9999,C9998 tests/
+	###### FLAKE8 #####
+	# No unused imports, no undefined vars,
+	flake8 --ignore=E731,W503,W504 --exclude chalice/__init__.py,chalice/compat.py --max-complexity 10 chalice/
+	flake8 --ignore=E731,W503,W504,F401 --max-complexity 10 chalice/compat.py
+	flake8 tests/unit/ tests/functional/ tests/integration
 
 test:
 	py.test -v $(TESTS)

--- a/chalice/awsclient.py
+++ b/chalice/awsclient.py
@@ -21,6 +21,7 @@ import zipfile
 import shutil
 import json
 import re
+from typing import Any, Optional, Dict, Callable, List, Iterator  # noqa
 import uuid
 
 import botocore.session  # noqa
@@ -30,7 +31,6 @@ from botocore.vendored.requests import ConnectionError as \
     RequestsConnectionError
 from botocore.vendored.requests.exceptions import ReadTimeout as \
     RequestsReadTimeout
-from typing import Any, Optional, Dict, Callable, List, Iterator  # noqa
 
 from chalice.constants import DEFAULT_STAGE_NAME
 from chalice.constants import MAX_LAMBDA_DEPLOYMENT_SIZE
@@ -198,7 +198,9 @@ class TypedAWSClient(object):
 
     def _get_layer_latest_arn(self, name):
         client = self._client('lambda')
-        params = { 'LayerName': name, }
+        params = {
+            'LayerName': name,
+        }
         marker, first = None, True
         versions = []
         while marker or first:

--- a/chalice/cli/__init__.py
+++ b/chalice/cli/__init__.py
@@ -10,11 +10,11 @@ import sys
 import tempfile
 import shutil
 import traceback
+from typing import Dict, Any, Optional  # noqa
 import functools
 
 import botocore.exceptions
 import click
-from typing import Dict, Any, Optional  # noqa
 
 from chalice import __version__ as chalice_version
 from chalice.app import Chalice  # noqa

--- a/chalice/cli/factory.py
+++ b/chalice/cli/factory.py
@@ -1,13 +1,13 @@
-import sys
-import os
+import functools
 import importlib
 import logging
-import functools
+import os
+import sys
+from typing import Any, Optional, Dict, MutableMapping  # noqa
 
 import click
 from botocore.config import Config as BotocoreConfig
 from botocore.session import Session
-from typing import Any, Optional, Dict, MutableMapping  # noqa
 import yaml
 from yaml.scanner import ScannerError
 
@@ -275,7 +275,7 @@ class CliFactory(object):
             # the legacy .json suffix.
             config_file = replace_yaml_extension(config_file)
         with open(config_file) as f:
-            return yaml.load(f)
+            return yaml.load(f, yaml.SafeLoader)
 
     def create_local_server(self, app_obj, config, host, port):
         # type: (Chalice, Config, str, int) -> local.LocalDevServer

--- a/chalice/config.py
+++ b/chalice/config.py
@@ -364,7 +364,7 @@ class Config(object):
         if not os.path.isfile(deployed_file):
             return None
         with open(deployed_file, 'r', encoding='utf-8') as f:
-            return yaml.load(f)
+            return yaml.load(f, yaml.SafeLoader)
 
     def _upgrade_deployed_values(self, chalice_stage_name, data):
         # type: (str, Any) -> DeployedResources

--- a/chalice/constants.py
+++ b/chalice/constants.py
@@ -187,18 +187,18 @@ CODEPIPELINE_POLICY = {
         }
     ]
 }
-FANCY_NAME = """
-        __          ___                                        ____      _ __ 
+FANCY_NAME = r"""
+        __          ___                                        ____      _ __
   _____/ /_  ____ _/ (_)_______       __     ____  ____ ______/ __/___ _(_) /_
  / ___/ __ \/ __ `/ / / ___/ _ \   __/ /_   / __ \/ __ `/ ___/ /_/ __ `/ / __/
-/ /__/ / / / /_/ / / / /__/  __/  /_  __/  / /_/ / /_/ / /  / __/ /_/ / / /_  
-\___/_/ /_/\__,_/_/_/\___/\___/    /_/    / .___/\__,_/_/  /_/  \__,_/_/\__/  
-                                         /_/      
+/ /__/ / / / /_/ / / / /__/  __/  /_  __/  / /_/ / /_/ / /  / __/ /_/ / / /_
+\___/_/ /_/\__,_/_/_/\___/\___/    /_/    / .___/\__,_/_/  /_/  \__,_/_/\__/
+                                         /_/
 
 """
 
 
-WELCOME_PROMPT = FANCY_NAME + r"""                                                                    
+WELCOME_PROMPT = FANCY_NAME + r"""
 Have fun. Don't forget to bookmark this website :)
 The python serverless microframework for AWS allows
 you to quickly create and deploy applications using

--- a/chalice/deploy/deployer.py
+++ b/chalice/deploy/deployer.py
@@ -86,12 +86,12 @@ import logging
 import os
 import socket
 import textwrap
+from typing import Optional, Dict, List, Any, Set, Tuple, cast  # noqa
 
 import botocore.exceptions
 from botocore.vendored.requests import ConnectionError as \
     RequestsConnectionError
 from botocore.session import Session  # noqa
-from typing import Optional, Dict, List, Any, Set, Tuple, cast  # noqa
 
 import yaml
 from chalice import app
@@ -804,7 +804,7 @@ class PolicyGenerator(BaseDeployStep):
                 # file
                 filename = replace_yaml_extension(filename)
             f = self._osutils.get_buffered_contents(filename)
-            resource.document = yaml.load(f)
+            resource.document = yaml.load(f, yaml.SafeLoader)
         except IOError as e:
             raise RuntimeError("Unable to load IAM policy file %s: %s"
                                % (resource.filename, e))

--- a/chalice/deploy/executor.py
+++ b/chalice/deploy/executor.py
@@ -1,6 +1,5 @@
-import jmespath
-
 from typing import Dict, List, Any  # noqa
+import jmespath
 
 from chalice.deploy import models
 from chalice.deploy.planner import Variable, StringFormat

--- a/chalice/local.py
+++ b/chalice/local.py
@@ -14,6 +14,7 @@ import re
 import sys
 import threading
 import time
+from typing import List, Any, Dict, Tuple, Callable, Optional, Union  # noqa
 from urllib.request import urlopen
 import uuid
 import warnings
@@ -22,7 +23,6 @@ from zipfile import ZipFile
 from six.moves.BaseHTTPServer import HTTPServer
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler
 from six.moves.socketserver import ThreadingMixIn
-from typing import List, Any, Dict, Tuple, Callable, Optional, Union  # noqa
 from botocore.session import Session
 import yaml
 from chalice.app import Chalice  # noqa
@@ -34,7 +34,6 @@ from chalice.app import AuthResponse  # noqa
 from chalice.app import BuiltinAuthConfig  # noqa
 from chalice.awsclient import TypedAWSClient
 from chalice.config import Config  # noqa
-
 from chalice.compat import urlparse, parse_qs
 
 
@@ -623,7 +622,8 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
 
 
 class LocalLayerDownloader:
-    def __init__(self, config: Optional[Config], session: Optional[Session] = None):
+    def __init__(
+            self, config: Optional[Config], session: Optional[Session] = None):
         if session:
             self.client = TypedAWSClient(session)
         else:
@@ -641,7 +641,7 @@ class LocalLayerDownloader:
         filename = os.path.join('.chalice/local_layers.yml')
         try:
             with open(filename, 'r', encoding='utf-8') as f:
-                self.layer_cache = yaml.load(f)
+                self.layer_cache = yaml.load(f, yaml.SafeLoader)
         except FileNotFoundError:
             pass
 
@@ -649,7 +649,9 @@ class LocalLayerDownloader:
         if self.layer_cache_dirty:
             filename = os.path.join('.chalice/local_layers.yml')
             with open(filename, 'w', encoding='utf-8') as f:
-                yaml.dump(self.layer_cache, f, default_flow_style=False)
+                yaml.dump(
+                    self.layer_cache, f, yaml.SafeDumper,
+                    default_flow_style=False)
 
     def normalize_layer_version(self, layers):
         for x in layers:

--- a/chalice/policy.py
+++ b/chalice/policy.py
@@ -46,7 +46,7 @@ def _load_yaml_file(relative_filename):
         os.path.dirname(os.path.abspath(__file__)),
         relative_filename)
     with open(path, encoding='utf-8') as f:
-        return yaml.load(f)
+        return yaml.load(f, yaml.SafeLoader)
 
 
 def diff_policies(old, new):

--- a/chalice/utils.py
+++ b/chalice/utils.py
@@ -7,13 +7,13 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from typing import IO, Dict, List, Any, Tuple, Iterator, BinaryIO  # noqa
+from typing import Optional, Union  # noqa
+from typing import MutableMapping  # noqa
 import zipfile
 
 import click
 import yaml
-from typing import IO, Dict, List, Any, Tuple, Iterator, BinaryIO  # noqa
-from typing import Optional, Union  # noqa
-from typing import MutableMapping  # noqa
 
 from chalice.constants import WELCOME_PROMPT
 
@@ -53,7 +53,7 @@ def remove_stage_from_deployed_values(key, filename):
     final_values = {}  # type: Dict[str, Any]
     try:
         with open(filename, 'r') as f:
-            final_values = yaml.load(f)
+            final_values = yaml.load(f, yaml.SafeLoader)
     except IOError:
         # If there is no file to delete from, then this funciton is a noop.
         return
@@ -78,7 +78,7 @@ def record_deployed_values(deployed_values, filename):
     final_values = {}  # type: Dict[str, Any]
     if os.path.isfile(filename):
         with open(filename, 'r') as f:
-            final_values = yaml.load(f)
+            final_values = yaml.load(f, yaml.SafeLoader)
     final_values.update(deployed_values)
     with open(filename, 'w', encoding='utf-8') as f:
         data = serialize_to_yaml(final_values)

--- a/docs/source/topics/multifile.rst
+++ b/docs/source/topics/multifile.rst
@@ -84,7 +84,7 @@ In our ``app.py`` code, we can load and use our config file:
     filename = os.path.join(
         os.path.dirname(__file__), 'chalicelib', 'config.yml')
     with open(filename) as f:
-        config = yaml.load(f)
+        config = yaml.load(f, yaml.SafeLoader)
 
     @app.route("/")
     def index():

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ install_requires = [
     'botocore>=1.10.48,<2.0.0',
     'typing==3.6.4',
     'six>=1.10.0,<2.0.0',
-    'pip>=9,<=18.1',
     'attrs==17.4.0',
     'enum-compat>=0.0.2',
     'jmespath>=0.9.3,<1.0.0',
@@ -23,7 +22,7 @@ install_requires = [
 
 setup(
     name='parfait',
-    version='0.2',
+    version='0.3',
     description="Microframework",
     long_description=README,
     author="James Saryerwinnie",

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -121,7 +121,7 @@ def test_gen_policy_command_creates_policy(runner):
         assert result.exit_code == 0
         # The output should be valid yaml.
         buffer = StringIO(result.output)
-        parsed_policy = yaml.load(buffer)
+        parsed_policy = yaml.load(buffer, yaml.SafeLoader)
         # We don't want to validate the specific parts of the policy
         # (that's tested elsewhere), but we'll check to make sure
         # it looks like a policy document.
@@ -270,7 +270,7 @@ def test_can_generate_pipeline_for_all(runner):
         assert result.exit_code == 0, result.output
         assert os.path.isfile('pipeline.yml')
         with open('pipeline.yml', 'r') as f:
-            template = yaml.load(f)
+            template = yaml.load(f, yaml.SafeLoader)
             # The actual contents are tested in the unit
             # tests.  Just a sanity check that it looks right.
             assert "AWSTemplateFormatVersion" in template
@@ -287,7 +287,7 @@ def test_no_errors_if_override_codebuild_image(runner):
         assert result.exit_code == 0, result.output
         assert os.path.isfile('pipeline.yml')
         with open('pipeline.yml', 'r') as f:
-            template = yaml.load(f)
+            template = yaml.load(f, yaml.SafeLoader)
             # The actual contents are tested in the unit
             # tests.  Just a sanity check that it looks right.
             image = template['Parameters']['CodeBuildImage']['Default']
@@ -306,7 +306,7 @@ def test_can_configure_github(runner):
         assert result.exit_code == 0, result.output
         assert os.path.isfile('pipeline.yml')
         with open('pipeline.yml', 'r') as f:
-            template = yaml.load(f)
+            template = yaml.load(f, yaml.SafeLoader)
             # The template is already tested in the unit tests
             # for template generation.  We just want a basic
             # sanity check to make sure things are mapped

--- a/tests/functional/test_awsclient.py
+++ b/tests/functional/test_awsclient.py
@@ -431,7 +431,9 @@ class TestCreateLambdaFunction(object):
         stubbed_session.stub('lambda').get_layer_version(
             LayerName='layer',
             VersionNumber=2,
-        ).returns({'LayerVersionArn': 'arn:aws:lambda:us-east-2:1234567890:layer:2'})
+        ).returns({
+            'LayerVersionArn': 'arn:aws:lambda:us-east-2:1234567890:layer:2'
+        })
         stubbed_session.stub('lambda').create_function(
             FunctionName='name',
             Runtime='python2.7',
@@ -454,7 +456,7 @@ class TestCreateLambdaFunction(object):
     def test_create_function_with_latest_layers(self, stubbed_session):
         stubbed_session.stub('lambda').list_layer_versions(
             LayerName='layer',
-        ).returns({ 'LayerVersions': [{
+        ).returns({'LayerVersions': [{
             'LayerVersionArn': 'arn:aws:lambda:us-east-2:1234567890:layer:1',
             'CreatedDate': '2019-01-05T03:49:59.116+0000',
         }, {

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -51,7 +51,7 @@ def test_can_write_recorded_values(tmpdir):
     filename = str(tmpdir.join('deployed.yml'))
     utils.record_deployed_values({'dev': {'deployed': 'foo'}}, filename)
     with open(filename, 'r') as f:
-        assert yaml.load(f) == {'dev': {'deployed': 'foo'}}
+        assert yaml.load(f, yaml.SafeLoader) == {'dev': {'deployed': 'foo'}}
 
 
 def test_can_merge_recorded_values(tmpdir):
@@ -63,7 +63,7 @@ def test_can_merge_recorded_values(tmpdir):
     combined = first.copy()
     combined.update(second)
     with open(filename, 'r') as f:
-        data = yaml.load(f)
+        data = yaml.load(f, yaml.SafeLoader)
     assert data == combined
 
 
@@ -81,7 +81,7 @@ def test_can_remove_stage_from_deployed_values(tmpdir):
     utils.remove_stage_from_deployed_values('dev', filename)
 
     with open(filename, 'r', encoding='utf-8') as f:
-        data = yaml.load(f)
+        data = yaml.load(f, yaml.SafeLoader)
     assert data == left_after_removal
 
 
@@ -96,7 +96,7 @@ def test_remove_stage_from_deployed_values_already_removed(tmpdir):
     utils.remove_stage_from_deployed_values('fake_key', filename)
 
     with open(filename, 'r', encoding='utf-8') as f:
-        data = yaml.load(f)
+        data = yaml.load(f, yaml.SafeLoader)
     assert data == deployed
 
 

--- a/tests/integration/test_features.py
+++ b/tests/integration/test_features.py
@@ -132,7 +132,7 @@ def smoke_test_app(tmpdir_factory):
 def _inject_app_name(dirname):
     config_filename = os.path.join(dirname, '.chalice', 'config.yml')
     with open(config_filename) as f:
-        data = yaml.load(f)
+        data = yaml.load(f, yaml.SafeLoader)
     data['app_name'] = RANDOM_APP_NAME
     data['stages']['dev']['environment_variables']['APP_NAME'] = \
         RANDOM_APP_NAME

--- a/tests/linter.py
+++ b/tests/linter.py
@@ -4,7 +4,7 @@ from astroid.exceptions import InferenceError
 
 
 def register(linter):
-    linter.register_checker(PatchChecker(linter))
+    pass
 
 
 class MocksUseSpecArg(BaseChecker):

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -6,7 +6,6 @@ import mock
 from pytest import fixture
 from six import BytesIO
 from six.moves.BaseHTTPServer import HTTPServer
-from botocore.session import Session
 from chalice import app
 from chalice import local, BadRequestError, CORSConfig
 from chalice import Response


### PR DESCRIPTION
With pyyaml 5.1, we must begin using `SafeLoader` explicitly to avoid warnings about how we load yaml configuration files.

